### PR TITLE
feat: global state provider and view manager

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import {
 } from 'native-base';
 import {getBerry} from './src/api/berry';
 import Footer from './src/components/Footer';
+import GlobalStateProvider from './src/components/Global';
 
 function UseColorMode() {
   const {toggleColorMode} = useColorMode();
@@ -24,8 +25,10 @@ const App = () => {
 
   return (
     <NativeBaseProvider>
-      <UseColorMode />
-      <Footer />
+      <GlobalStateProvider>
+        <UseColorMode />
+        <Footer />
+      </GlobalStateProvider>
     </NativeBaseProvider>
   );
 };

--- a/App.tsx
+++ b/App.tsx
@@ -1,32 +1,14 @@
-import {Berries} from 'pokenode-ts';
 import React from 'react';
-import {
-  NativeBaseProvider,
-  useColorMode,
-  useColorModeValue,
-  Center,
-  Button,
-} from 'native-base';
-import {getBerry} from './src/api/berry';
+import {NativeBaseProvider} from 'native-base';
 import Footer from './src/components/Footer';
 import GlobalStateProvider from './src/components/Global';
-
-function UseColorMode() {
-  const {toggleColorMode} = useColorMode();
-  return (
-    <Center flex="1" bg={useColorModeValue('warmGray.50', 'coolGray.800')}>
-      <Button onPress={toggleColorMode}>Toggle</Button>
-    </Center>
-  );
-}
+import ViewManager from './src/components/ViewManager';
 
 const App = () => {
-  getBerry(Berries.AGUAV);
-
   return (
     <NativeBaseProvider>
       <GlobalStateProvider>
-        <UseColorMode />
+        <ViewManager />
         <Footer />
       </GlobalStateProvider>
     </NativeBaseProvider>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -12,9 +12,17 @@ import {
   AddIcon,
   useColorModeValue,
 } from 'native-base';
+import {useGlobalDispatch, useGlobalState} from './Global';
 
 const Footer = () => {
-  const [selected, setSelected] = React.useState(1);
+  const [viewState] = useGlobalState();
+  const [setViewState] = useGlobalDispatch();
+
+  const onPressHook = (view: number) => {
+    setViewState(view);
+    console.log('Current view state: ', view);
+  };
+
   return (
     <Box flex={1}>
       <Center flex={1} bg={useColorModeValue('warmGray.50', 'coolGray.800')} />
@@ -25,10 +33,10 @@ const Footer = () => {
         shadow={6}>
         <Pressable
           cursor="pointer"
-          opacity={selected === 0 ? 1 : 0.5}
+          opacity={viewState === 0 ? 1 : 0.5}
           py="3"
           flex={1}
-          onPress={() => setSelected(0)}>
+          onPress={() => onPressHook(0)}>
           <Center>
             <SunIcon size="4" />
             <Text fontSize="12"> Pokedex </Text>
@@ -36,10 +44,10 @@ const Footer = () => {
         </Pressable>
         <Pressable
           cursor="pointer"
-          opacity={selected === 1 ? 1 : 0.5}
+          opacity={viewState === 1 ? 1 : 0.5}
           py="2"
           flex={1}
-          onPress={() => setSelected(1)}>
+          onPress={() => onPressHook(1)}>
           <Center>
             <MoonIcon size="4" />
             <Text fontSize="12">Moves</Text>
@@ -47,10 +55,10 @@ const Footer = () => {
         </Pressable>
         <Pressable
           cursor="pointer"
-          opacity={selected === 2 ? 1 : 0.6}
+          opacity={viewState === 2 ? 1 : 0.6}
           py="2"
           flex={1}
-          onPress={() => setSelected(2)}>
+          onPress={() => onPressHook(2)}>
           <Center>
             <SearchIcon size="4" />
             <Text fontSize="12">Type Chart</Text>
@@ -58,10 +66,10 @@ const Footer = () => {
         </Pressable>
         <Pressable
           cursor="pointer"
-          opacity={selected === 3 ? 1 : 0.5}
+          opacity={viewState === 3 ? 1 : 0.5}
           py="2"
           flex={1}
-          onPress={() => setSelected(3)}>
+          onPress={() => onPressHook(3)}>
           <Center>
             <CheckIcon size="4" />
             <Text fontSize="12">Abilities</Text>
@@ -69,10 +77,10 @@ const Footer = () => {
         </Pressable>
         <Pressable
           cursor="pointer"
-          opacity={selected === 4 ? 1 : 0.5}
+          opacity={viewState === 4 ? 1 : 0.5}
           py="2"
           flex={1}
-          onPress={() => setSelected(4)}>
+          onPress={() => onPressHook(4)}>
           <Center>
             <AddIcon size="4" />
             <Text fontSize="12">Items</Text>

--- a/src/components/Global.tsx
+++ b/src/components/Global.tsx
@@ -1,0 +1,26 @@
+import React, {createContext, Dispatch, useContext, useReducer} from 'react';
+
+const defaultViewState = 0;
+export const GlobalStateContext = createContext(defaultViewState);
+export const DispatchStateContext = createContext({} as Dispatch<any>);
+
+export const useGlobalState = () => [useContext(GlobalStateContext)];
+export const useGlobalDispatch = () => [useContext(DispatchStateContext)];
+
+// GlobalStateProvider provides view state value to all child components
+const GlobalStateProvider = ({children}: any) => {
+  const [viewState, setViewState] = useReducer(
+    (state: number, newValue: number) => newValue,
+    defaultViewState,
+  );
+
+  return (
+    <GlobalStateContext.Provider value={viewState}>
+      <DispatchStateContext.Provider value={setViewState}>
+        {children}
+      </DispatchStateContext.Provider>
+    </GlobalStateContext.Provider>
+  );
+};
+
+export default GlobalStateProvider;

--- a/src/components/ViewManager.tsx
+++ b/src/components/ViewManager.tsx
@@ -1,0 +1,43 @@
+import {useGlobalState} from './Global';
+import {Center, Text} from 'native-base';
+import React, {useEffect, useState} from 'react';
+
+// ViewManager handles the currently displayed view
+const ViewManager = () => {
+  const [viewState] = useGlobalState();
+  const [displayedView, setDisplayedView] = useState(<Text>Pokedex</Text>);
+
+  // When the view state is updated, get the new view based
+  // on the new state and set that value
+  useEffect(() => {
+    const view = getView(viewState);
+    setDisplayedView(view);
+  }, [viewState]);
+
+  const getView = (state: number) => {
+    switch (state) {
+      case 0: {
+        return <Text>Pokedex</Text>;
+      }
+      case 1: {
+        return <Text>Moves</Text>;
+      }
+      case 2: {
+        return <Text>Type Chart</Text>;
+      }
+      case 3: {
+        return <Text>Abilities</Text>;
+      }
+      case 4: {
+        return <Text>Items</Text>;
+      }
+      default: {
+        return <Text>Uh Oh!</Text>;
+      }
+    }
+  };
+
+  return <Center flex="1">{displayedView}</Center>;
+};
+
+export default ViewManager;


### PR DESCRIPTION
Adds a global state provider which allows any child component to get/set the state of the current view selection.

Based on the current view state we can render the correct component using the view manager.

also cleans up `App` and adds some missing imports

this is really just a first stab at solving this problem, we can try it out and see how it works and refactor as needed.

closes #6 