### PR TITLE
feat: Display stats on pokemon detail page

### DIFF
--- a/src/api/pokemon.ts
+++ b/src/api/pokemon.ts
@@ -20,10 +20,10 @@ export const getPokemonList = async (): Promise<PokemonListData> => {
 };
 
 // getPokemon returns individual pokemon data
-export const getPokemon = async (name: string): Promise<PokemonData> => {
-  console.log(name);
+export const getPokemon = async (id: number): Promise<PokemonData> => {
+  console.log(id);
   return await api
-    .getPokemonByName(name)
+    .getPokemonById(id)
     .then(data => {
       return data as PokemonData;
     })

--- a/src/api/pokemon.ts
+++ b/src/api/pokemon.ts
@@ -1,5 +1,5 @@
-import {NamedAPIResource, PokemonClient} from 'pokenode-ts';
-import {PokemonListData, PokemonData} from 'types/pokemon';
+import {NamedAPIResource, PokemonClient, PokemonStat} from 'pokenode-ts';
+import {PokemonListData, PokemonData, Stat} from 'types/pokemon';
 
 // initialize our client
 const api = new PokemonClient({
@@ -31,4 +31,28 @@ export const getPokemon = async (name: string): Promise<PokemonData> => {
       console.error(error);
       return undefined;
     });
+};
+
+export const formatStats = (stats_array: Array<PokemonStat>): Object => {
+  var stats: Stat[] = [];
+  for (let stat of stats_array) {
+    var stat_formatted: Stat = {name: 'not_found', value: 0, max: 0, min: 0};
+
+    stat_formatted.name = stat.stat.name;
+    stat_formatted.value = stat.base_stat;
+    if (stat_formatted.name === 'hp') {
+      stat_formatted.min = Math.trunc(
+        0.01 * Math.trunc(2 * stat.base_stat * 100) + 110,
+      );
+      stat_formatted.max = Math.trunc(stat.base_stat * 2 + 204);
+    } else {
+      stat_formatted.min = Math.trunc(
+        (0.01 * Math.trunc(2 * stat.base_stat * 100) + 5) * 0.9,
+      );
+      stat_formatted.max = Math.trunc((stat.base_stat * 2 + 99) * 1.1);
+    }
+
+    stats.push(stat_formatted);
+  }
+  return stats;
 };

--- a/src/api/pokemon.ts
+++ b/src/api/pokemon.ts
@@ -56,3 +56,22 @@ export const formatStats = (stats_array: Array<PokemonStat>): Object => {
   }
   return stats;
 };
+
+export const formatStatName = (statname: String) => {
+  switch (statname) {
+    case 'hp':
+      return 'HP';
+    case 'attack':
+      return 'Attack';
+    case 'defense':
+      return 'Defense';
+    case 'special-attack':
+      return 'Sp. Atk';
+    case 'special-defense':
+      return 'Sp. Def';
+    case 'speed':
+      return 'Speed';
+    default:
+      return 'Unknown!';
+  }
+};

--- a/src/components/PokemonDetail.tsx
+++ b/src/components/PokemonDetail.tsx
@@ -21,13 +21,13 @@ const PokemonDetail = (props: PokemonDetailProps) => {
         console.error('pokemon detail sent undefined props');
         return;
       }
-      const data: PokemonData = await getPokemon(props.route.params.name);
+      const data: PokemonData = await getPokemon(props.route.params.id);
       if (data === undefined) {
         console.error('undefined response from get pokemon api');
         setPokemon(undefined);
         return;
       }
-      console.log(JSON.stringify(data.stats));
+      console.log('Moves:' + JSON.stringify(data.moves));
       setPokemon(data);
     };
     fetchPokemonDetail();

--- a/src/components/PokemonDetail.tsx
+++ b/src/components/PokemonDetail.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import {PokemonData} from 'types/pokemon';
 import {Box, VStack, Text, Image, Center} from 'native-base';
-import {getPokemon} from 'api/pokemon';
+import {getPokemon, formatStats} from 'api/pokemon';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {RouteProp} from '@react-navigation/native';
 import {getImageBasedOnMode, titleCaseWord} from 'utils/utils';
+import {PokemonDetailStats} from 'components/PokemonDetailStats';
 
 export interface PokemonDetailProps {
   route: RouteProp<any>;
@@ -23,9 +24,10 @@ const PokemonDetail = (props: PokemonDetailProps) => {
       const data: PokemonData = await getPokemon(props.route.params.name);
       if (data === undefined) {
         console.error('undefined response from get pokemon api');
+        setPokemon(undefined);
         return;
       }
-      console.log(data.sprites);
+      console.log(JSON.stringify(data.stats));
       setPokemon(data);
     };
     fetchPokemonDetail();
@@ -54,6 +56,7 @@ const PokemonDetail = (props: PokemonDetailProps) => {
               <Text>Height: {pokemon.height / 10} m</Text>
             </Center>
           </Center>
+          <PokemonDetailStats items={formatStats(pokemon.stats)} />
         </VStack>
       ) : (
         <Text>Uh Oh!</Text>

--- a/src/components/PokemonDetailStats.tsx
+++ b/src/components/PokemonDetailStats.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import {Stat} from 'types/pokemon';
+import {Box, Text, FlatList} from 'native-base';
+
+export const PokemonDetailStats = (props: Array<Stat>) => {
+  console.log(props);
+  return (
+    <Box>
+      <FlatList
+        data={props.items}
+        renderItem={({item}) => (
+          <Text>
+            {item.name.toUpperCase()}: {item.value} - Min: {item.min} - Max:{' '}
+            {item.max}
+          </Text>
+        )}
+      />
+    </Box>
+  );
+};

--- a/src/components/PokemonDetailStats.tsx
+++ b/src/components/PokemonDetailStats.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Stat} from 'types/pokemon';
 import {Box, Text, FlatList} from 'native-base';
+import {formatStatName} from 'api/pokemon';
 
 export const PokemonDetailStats = (props: Array<Stat>) => {
   console.log(props);
@@ -10,7 +11,7 @@ export const PokemonDetailStats = (props: Array<Stat>) => {
         data={props.items}
         renderItem={({item}) => (
           <Text>
-            {item.name.toUpperCase()}: {item.value} - Min: {item.min} - Max:{' '}
+            {formatStatName(item.name)}: {item.value} - Min: {item.min} - Max:{' '}
             {item.max}
           </Text>
         )}

--- a/src/components/PokemonList.tsx
+++ b/src/components/PokemonList.tsx
@@ -30,7 +30,7 @@ const PokemonList = (props: PokemonListProps) => {
     const pokemons: NamedAPIResource[] = data.map(mon => ({
       name: mon.name,
       url: mon.url,
-      id: Math.random().toString(12).substring(0),
+      id: getPokeNum(mon.url),
       img: getImageBasedOnMode(
         `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${getPokeNum(
           mon.url,

--- a/src/types/pokemon.ts
+++ b/src/types/pokemon.ts
@@ -2,3 +2,9 @@ import {NamedAPIResource, Pokemon} from 'pokenode-ts';
 
 export type PokemonListData = NamedAPIResource[] | undefined;
 export type PokemonData = Pokemon | undefined;
+export interface Stat {
+  name: string;
+  value: number;
+  max: number;
+  min: number;
+}


### PR DESCRIPTION
 - Added a Stat interface for the pokemon Stats object
 - Added a function to organize the Stats object returned from the API. Function also calculates the min and max value for each stat.
 - Added a component to display the stats with rudimentary styling

We might think about using the abbreviations PokemonDB uses for its stats: https://pokemondb.net/pokedex/venusaur